### PR TITLE
Add travis-ci job to release aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,46 @@ matrix:
     env:
     - MB_PYTHON_VERSION=3.9
     - PLAT=i686
+  - os: linux
+    arch: arm64-graviton2
+    dist: focal
+    virt: vm
+    group: edge
+    env:
+    - MB_PYTHON_VERSION=3.6
+    - PLAT=aarch64
+    - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+  - os: linux
+    arch: arm64-graviton2
+    dist: focal
+    virt: vm
+    group: edge
+    env:
+    - MB_PYTHON_VERSION=3.7
+    - PLAT=aarch64
+    - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+  - os: linux
+    arch: arm64-graviton2
+    dist: focal
+    virt: vm
+    group: edge
+    env:
+    - MB_PYTHON_VERSION=3.8
+    - PLAT=aarch64
+    - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+  - os: linux
+    arch: arm64-graviton2
+    dist: focal
+    virt: vm
+    group: edge
+    env:
+    - MB_PYTHON_VERSION=3.9
+    - PLAT=aarch64
+    - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
   - os: osx
     language: generic
     env:


### PR DESCRIPTION
Owner: Madhukar
Fix: Add travis-ci job to release aarch64 wheels
Reviewer: Pruthvi, Shobhit
Build Logs: https://travis-ci.com/github/odidev/pyproj-wheels/jobs/459339003